### PR TITLE
ensure qt selectors work correctly

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-12
+    vmImage: macOS-13
   strategy:
     matrix:
       osx_64_python3.10.____cpythonqt5:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,32 @@
 # update the conda-forge.yml and/or the recipe/meta.yaml.
 # -*- mode: yaml -*-
 
-jobs:
-  - template: ./.azure-pipelines/azure-pipelines-linux.yml
-  - template: ./.azure-pipelines/azure-pipelines-osx.yml
-  - template: ./.azure-pipelines/azure-pipelines-win.yml
+stages:
+- stage: Check
+  jobs:
+    - job: Skip
+      pool:
+        vmImage: 'ubuntu-22.04'
+      variables:
+        DECODE_PERCENTS: 'false'
+        RET: 'true'
+      steps:
+      - checkout: self
+        fetchDepth: '2'
+      - bash: |
+          git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
+          echo "##vso[task.setvariable variable=log]$git_log"
+        displayName: Obtain commit message
+      - bash: echo "##vso[task.setvariable variable=RET]false"
+        condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+        displayName: Skip build?
+      - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
+        name: result
+        displayName: Export result
+- stage: Build
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
+  jobs:
+    - template: ./.azure-pipelines/azure-pipelines-linux.yml
+    - template: ./.azure-pipelines/azure-pipelines-osx.yml
+    - template: ./.azure-pipelines/azure-pipelines-win.yml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ source:
 
 build:
   number: 1
+  string: py{{ CONDA_PY }}qt{{ qt }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}
   script_env:
   {% if qt|int >=6 %}
     - USE_QT6=1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,10 @@
 {% set name = "pivy" %}
 {% set version = "0.6.9" %}
 
+{% if qt is undefined %}
+{% set qt = "6" %}
+{% endif %}
+
 package:
   name: {{ name }}
   version: {{ version }}
@@ -11,11 +15,14 @@ source:
   sha256: c207f5ed73089b2281356da4a504c38faaab90900b95639c80772d9d25ba0bbc
 
 build:
-  number: 0
+  number: 1
   script_env:
-    - USE_QT6=1  # [qt == 6]
-    - USE_QT6=0  # [qt == 5]
-  skip: true     # [qt == 5 and py > 311]
+  {% if qt|int >=6 %}
+    - USE_QT6=1
+  {% else %}
+    - USE_QT6=0
+  skip: true     # [py>311]
+  {% endif %}
 
 requirements:
   build:
@@ -31,10 +38,13 @@ requirements:
   host:
     - python
     - coin3d
-    - soqt      # [qt == 5]
-    - qt-main   # [qt == 5]
-    - soqt6     # [qt == 6]
-    - qt6-main  # [qt == 6]
+  {% if qt|int >=6 %}
+    - qt6-main
+    - soqt6
+  {% else %}
+    - qt-main
+    - soqt
+  {% endif %}
   run:
     - python
 


### PR DESCRIPTION
selectors are full of traps for the unwary that end up making them not work as expected. One issue here is the use of strings in
https://github.com/conda-forge/pivy-feedstock/blob/dd6f8aa267d50cbf46098d4c794e9e263591259a/recipe/conda_build_config.yaml#L9-L11
vs. ints (implicitly) in the recipe, but even if that is rectified, the selectors do not work correctly. Instead of trying to make them work, switch to a jinja-based approach that's less error-prone (even though it is more ugly...)